### PR TITLE
[FEAT] : 댓글 관련 로직 추가(로그인 된 id, 댓글 작성id 값비교), 댓글 삭제 로직 수정, 프론트엔드 / 댓글 …

### DIFF
--- a/src/main/java/com/gunwook/jpeople/comment/controller/CommentController.java
+++ b/src/main/java/com/gunwook/jpeople/comment/controller/CommentController.java
@@ -55,4 +55,18 @@ public class CommentController {
         String result = commentService.deleteComment(userDetails.getUser(), comment_id);
         return ResponseEntity.ok(result);
     }
+
+    /**
+     * 로그인 되어있는 유저와 댓글 유저의 id값 비교
+     * @param userDetails 로그인 유저
+     * @param comment_id 댓글 아이디
+     * @return 일치, 불일치 여부
+     */
+    @GetMapping("/comment/{comment_id}/user")
+    ResponseEntity<Boolean> getCommentUser(@AuthenticationPrincipal UserDetailsImpl userDetails,
+                                           @PathVariable Long comment_id){
+        Boolean result = commentService.getCommentUser(userDetails.getUser(), comment_id);
+        return ResponseEntity.ok(result);
+    }
+
 }

--- a/src/main/java/com/gunwook/jpeople/comment/service/CommentService.java
+++ b/src/main/java/com/gunwook/jpeople/comment/service/CommentService.java
@@ -7,6 +7,7 @@ import com.gunwook.jpeople.post.dto.PostResponseDto;
 import com.gunwook.jpeople.post.entity.Post;
 import com.gunwook.jpeople.post.repository.PostRepository;
 import com.gunwook.jpeople.user.entity.User;
+import com.gunwook.jpeople.user.entity.UserRoleEnum;
 import com.gunwook.jpeople.user.repository.UserRepository;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
@@ -51,11 +52,26 @@ public class CommentService {
                 () -> new IllegalArgumentException("존재하지 않는 댓글입니다.")
         );
 
-        if(!comment.getUser().getId().equals(user.getId())){
+        if(comment.getUser().getId().equals(user.getId()) || user.getRole().equals(UserRoleEnum.ADMIN)){
+            commentRepository.delete(comment);
+            return "댓글이 삭제되었습니다.";
+        } else{
             throw new IllegalArgumentException("댓글 작성자만 삭제가 가능합니다.");
         }
+    }
 
-        commentRepository.delete(comment);
-        return "댓글이 삭제되었습니다.";
+    public Boolean getCommentUser(User user, Long commentId) {
+        Boolean result;
+        Comment comment = commentRepository.findById(commentId).orElseThrow(
+                () -> new IllegalArgumentException("댓글이 존재하지 않습니다.")
+        );
+
+        if(user.getId().equals(comment.getUser().getId()) || user.getRole().equals(UserRoleEnum.ADMIN)){
+            result = true;
+        } else{
+            result = false;
+        }
+
+        return result;
     }
 }

--- a/src/main/resources/templates/boarddetail.html
+++ b/src/main/resources/templates/boarddetail.html
@@ -109,6 +109,8 @@
             .catch(error => console.error('Error checking user:', error));
     });
 
+
+
     // 톱니바퀴 숨기기 함수
     function hideSettings() {
         var settingsIcon = document.getElementById('settingsIcon');
@@ -311,6 +313,25 @@
             })
             .catch(error => console.error('Error fetching post:', error));
     });
+    function commentCheck(commentId) {
+        const xhr = new XMLHttpRequest();
+        xhr.open('GET', `/api/comment/${commentId}/user`, false);  // Using synchronous request for simplicity, consider using asynchronous in a real application
+        xhr.setRequestHeader('Authorization', 'Bearer ' + localStorage.getItem('accessToken'));
+
+        let result;
+
+        xhr.onload = function () {
+            if (xhr.status === 200) {
+                result = JSON.parse(xhr.responseText);
+            } else {
+                console.error('Error checking comment user:', xhr.status, xhr.statusText);
+            }
+        };
+
+        xhr.send();
+
+        return result;
+    }
 
     function addCommentToDOM(comment) {
         const commentContainer = document.querySelector('.comment > div');
@@ -320,39 +341,45 @@
 
         const timeAgoString = getTimeAgoString(comment.createdAt);
 
+        // 현재 댓글의 ID를 가져와서 commentCheck 함수 호출
+        const commentId = comment.id;
+        const showCommentSettings = commentCheck(commentId);
+
         commentElement.innerHTML = `
     <div style="position: relative; padding-bottom: 20px; background-color: #FAFAFA">
-        <img class="comment-settings-icon" src="/images/setting.png" alt="comment settings icon" style="width: 20px; height: 20px; cursor: pointer; position: absolute; top: 10px; right: 10px;" onclick="toggleCommentButtons(${comment.id})">
-        <!-- 수정/삭제 버튼 -->
-        <div id="editButtons_${comment.id}" style="display: none; position: absolute; top: 30px; right: 0; background-color: white; border: 1px solid #ccc; border-radius: 5px; box-shadow: 2px 2px 5px rgba(0,0,0,0.1); text-align: left;">
-            <button style="border: none; background-color: white; font-size: 14px; cursor: pointer; display: block; width: 100%;" onclick="editComment(${comment.id}, '${comment.contents}')">수정</button>
-            <button style="border: none; background-color: white; font-size: 14px; cursor: pointer; display: block; width: 100%;" onclick="deleteComment(${comment.id})">삭제</button>
-       </div>
-        <div style="text-align: left; padding-left: 20px;">
-            <span style="font-weight: bold">${comment.nickname}</span><br>
-            <span>${timeAgoString}</span><br>
-        </div>
-        <div style="display: flex; align-items: center; text-align: left; padding-left: 20px;">
-            <span>${comment.contents}</span>
-            <div style="display: flex; align-items: center;">
-                <img src="/images/like.png" alt="like icon" style="width: 30px; height: 30px; cursor: pointer;" onclick="likeComment(${comment.id})">
-                <span id="likeCount_${comment.id}">${comment.like}</span>
+        ${showCommentSettings ? `
+            <img id="CommentSettingsIcon" class="comment-settings-icon" src="/images/setting.png" alt="comment settings icon" style="width: 20px; height: 20px; cursor: pointer; position: absolute; top: 10px; right: 10px;" onclick="toggleCommentButtons(${comment.id})">
+            <!-- 수정/삭제 버튼 -->
+             <div id="editButtons_${comment.id}" style="position: absolute; top: 30px; right: 0; display: none; background-color: white; border: 1px solid #ccc; border-radius: 5px; box-shadow: 2px 2px 5px rgba(0,0,0,0.1); text-align: left;">
+                <button style="border: none; background-color: white; font-size: 14px; cursor: pointer; display: block; width: 100%;" onclick="editComment(${comment.id}, '${comment.contents}')">수정</button>
+                <button style="border: none; background-color: white; font-size: 14px; cursor: pointer; display: block; width: 100%;" onclick="deleteComment(${comment.id})">삭제</button>
+            </div>
+            ` : ''}
+            <div style="text-align: left; padding-left: 20px;">
+                <span style="font-weight: bold">${comment.nickname}</span><br>
+                <span>${timeAgoString}</span><br>
+            </div>
+            <div style="display: flex; align-items: center; text-align: left; padding-left: 20px;">
+                <span>${comment.contents}</span>
+                <div style="display: flex; align-items: center;">
+                    <img src="/images/like.png" alt="like icon" style="width: 30px; height: 30px; cursor: pointer;" onclick="likeComment(${comment.id})">
+                    <span id="likeCount_${comment.id}">${comment.like}</span>
+                </div>
             </div>
         </div>
-    </div>
     `;
 
         commentContainer.appendChild(commentElement);
     }
 
+    // 예시: 톱니바퀴를 눌렀을 때 호출되는 함수
     function toggleCommentButtons(commentId) {
-        // 댓글의 수정/삭제 버튼을 찾아옵니다.
-        const editButtons = document.querySelector(`#editButtons_${commentId}`);
-
-        // 수정/삭제 버튼을 토글합니다.
-        editButtons.style.display = editButtons.style.display === 'none' ? 'block' : 'none';
-
+        const editButtons = document.getElementById(`editButtons_${commentId}`);
+        // 현재 상태를 확인하고 반대로 토글
+        editButtons.style.display = (editButtons.style.display === 'none') ? 'block' : 'none';
     }
+
+
 
     function editComment(commentId, currentContents) {
         // 기본 제공하는 prompt 창을 사용하여 댓글 수정


### PR DESCRIPTION
## 개요
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
CommentController에 현재 로그인된 사용자의 id와 댓글 작성자의 id를 비교해서 true/false를 반환하는 로직을 추가했습니다.
관리자는 댓글 작성자가 아니더라도 댓글 삭제가 가능합니다.
자신이 작성한 댓글 목록에는 톱니바퀴 모양이 표시됩니다. 이 버튼으로 댓글을 수정/삭제가 가능합니다.
<!---- Resolves: #(Isuue Number) -->

## PR 유형
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.  Commit message convention 참고  (Ctrl + 클릭하세요.)
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).