### PR TITLE
[FIX] : 프론트에서 게시글 조회시 조회수가 2씩 증가하던 버그 수정(2)

### DIFF
--- a/src/main/resources/templates/boarddetail.html
+++ b/src/main/resources/templates/boarddetail.html
@@ -296,6 +296,7 @@
         }
     }
 
+
     function commentCheck(commentId) {
         const xhr = new XMLHttpRequest();
         xhr.open('GET', `/api/comment/${commentId}/user`, false);  // Using synchronous request for simplicity, consider using asynchronous in a real application
@@ -522,6 +523,14 @@
                 document.getElementById('contentss').textContent = postInfo.contents;
                 document.getElementById('viewCnts').textContent = postInfo.viewCnt;
                 document.getElementById('goodLikes').textContent = postInfo.goodLike;
+
+                // 가져온 댓글 정보를 화면에 표시
+                const commentList = postInfo.commentResponseDtoList.reverse();
+                const commentContainer = document.querySelector('.comment > div');
+
+                commentList.forEach(comment => {
+                    addCommentToDOM(comment);
+                });
             })
             .catch(error => console.error('Error fetching post:', error));
     });


### PR DESCRIPTION
## 개요
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
이전 FIX목록에서 조회수 중복증가 해결을 위해 사용했던 코드가 댓글리스트를 지우는 오류가 발생했습니다.
코드를 병합하여 조회수를 증가시키는 메서드의 호출빈도수를 정상적으로 조절하였습니다.
<!---- Resolves: #(Isuue Number) -->

## PR 유형
어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.  Commit message convention 참고  (Ctrl + 클릭하세요.)
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).