### PR TITLE
[FEAT] : 닉네임, 자기소개 변경 로직 수정 + 회원가입시 닉네임, 자기소개 글자수 제한

### DIFF
--- a/src/main/java/com/gunwook/jpeople/mypage/controller/MypageController.java
+++ b/src/main/java/com/gunwook/jpeople/mypage/controller/MypageController.java
@@ -1,14 +1,15 @@
 package com.gunwook.jpeople.mypage.controller;
 
 import com.gunwook.jpeople.comment.dto.CommentResponseDto;
-import com.gunwook.jpeople.mypage.dto.ProfileModifyRequestDto;
 import com.gunwook.jpeople.mypage.dto.ProfileResponseDto;
+import com.gunwook.jpeople.mypage.dto.UpdateIntroduction;
+import com.gunwook.jpeople.mypage.dto.UpdateNickname;
 import com.gunwook.jpeople.mypage.service.MyPageService;
 import com.gunwook.jpeople.post.dto.PostResponseDto;
 import com.gunwook.jpeople.post.service.S3Uploader;
 import com.gunwook.jpeople.security.UserDetailsImpl;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
@@ -22,18 +23,30 @@ import java.util.List;
 @RequestMapping("/api")
 public class MypageController {
     private final MyPageService myPageService;
-    private final S3Uploader s3Uploader;
 
     /**
-     * 닉네임, 자기소개 변경
+     * 닉네임 변경
      * @param userDetails 로그인 정보
-     * @param profileModifyRequestDto 수정 정보
-     * @return 결과 반환
+     * @param nickname 변경할 닉네임
+     * @return 성공/실패 여부
+     */
+    @PutMapping("/mypage/profile/nickname")
+    public ResponseEntity<String> updateNickname(@AuthenticationPrincipal UserDetailsImpl userDetails,
+                                                 @Valid @RequestBody UpdateNickname nickname){
+        String result = myPageService.updateNickname(userDetails.getUser(), nickname);
+        return ResponseEntity.ok(result);
+    }
+
+    /**
+     * 자기소개 변경
+     * @param userDetails 로그인 정보
+     * @param introduction 변경할 자기소개
+     * @return 성공/실패 여부
      */
     @PutMapping("/mypage/profile/introduction")
-    public ResponseEntity<String> introductionModify(@AuthenticationPrincipal UserDetailsImpl userDetails,
-                                                     @RequestBody ProfileModifyRequestDto profileModifyRequestDto){
-        String result = myPageService.introductionModify(userDetails.getUser(), profileModifyRequestDto);
+    public ResponseEntity<String> updateIntroduction(@AuthenticationPrincipal UserDetailsImpl userDetails,
+                                                 @Valid @RequestBody UpdateIntroduction introduction){
+        String result = myPageService.updateIntroduction(userDetails.getUser(), introduction);
         return ResponseEntity.ok(result);
     }
 

--- a/src/main/java/com/gunwook/jpeople/mypage/dto/UpdateIntroduction.java
+++ b/src/main/java/com/gunwook/jpeople/mypage/dto/UpdateIntroduction.java
@@ -1,0 +1,11 @@
+package com.gunwook.jpeople.mypage.dto;
+
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+
+@Getter
+public class UpdateIntroduction {
+
+    @Size(max=20)
+    private String introduction;
+}

--- a/src/main/java/com/gunwook/jpeople/mypage/dto/UpdateNickname.java
+++ b/src/main/java/com/gunwook/jpeople/mypage/dto/UpdateNickname.java
@@ -1,9 +1,11 @@
 package com.gunwook.jpeople.mypage.dto;
 
+import jakarta.validation.constraints.Size;
 import lombok.Getter;
 
 @Getter
-public class ProfileModifyRequestDto {
+public class UpdateNickname {
+
+    @Size(max = 7)
     private String nickname;
-    private String introduction;
 }

--- a/src/main/java/com/gunwook/jpeople/mypage/service/MyPageService.java
+++ b/src/main/java/com/gunwook/jpeople/mypage/service/MyPageService.java
@@ -3,8 +3,9 @@ package com.gunwook.jpeople.mypage.service;
 import com.gunwook.jpeople.comment.dto.CommentResponseDto;
 import com.gunwook.jpeople.comment.entity.Comment;
 import com.gunwook.jpeople.comment.repository.CommentRepository;
-import com.gunwook.jpeople.mypage.dto.ProfileModifyRequestDto;
 import com.gunwook.jpeople.mypage.dto.ProfileResponseDto;
+import com.gunwook.jpeople.mypage.dto.UpdateIntroduction;
+import com.gunwook.jpeople.mypage.dto.UpdateNickname;
 import com.gunwook.jpeople.post.dto.PostResponseDto;
 import com.gunwook.jpeople.post.entity.Category;
 import com.gunwook.jpeople.post.entity.Post;
@@ -14,8 +15,6 @@ import com.gunwook.jpeople.user.entity.User;
 import com.gunwook.jpeople.user.repository.UserRepository;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -32,14 +31,25 @@ public class MyPageService {
     private final CommentRepository commentRepository;
     private final S3Uploader s3Uploader;
 
+
     @Transactional
-    public String introductionModify(User user, ProfileModifyRequestDto profileModifyRequestDto) {
+    public String updateNickname(User user, UpdateNickname nickname){
         User requestUser = userRepository.findById(user.getId()).orElseThrow(
                 () -> new IllegalArgumentException("로그인 후 사용하세요.")
         );
 
-        requestUser.updateIntroduction(profileModifyRequestDto);
-        return "프로필 변경이 완료되었습니다.";
+        requestUser.updateNickname(nickname.getNickname());
+        return "닉네임이 변경되었습니다.";
+    }
+
+    @Transactional
+    public String updateIntroduction(User user, UpdateIntroduction introduction) {
+        User requestUser = userRepository.findById(user.getId()).orElseThrow(
+                () -> new IllegalArgumentException("로그인 후 사용하세요.")
+        );
+
+        requestUser.updateIntroduction(introduction.getIntroduction());
+        return "자기소개가 변경되었습니다.";
     }
 
     @Transactional

--- a/src/main/java/com/gunwook/jpeople/user/dto/SignUpRequestDto.java
+++ b/src/main/java/com/gunwook/jpeople/user/dto/SignUpRequestDto.java
@@ -1,6 +1,7 @@
 package com.gunwook.jpeople.user.dto;
 
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -16,9 +17,11 @@ public class SignUpRequestDto {
     private String password;
 
     @NotBlank(message =  "닉네임을 입력해주세요.")
+    @Size(max=7)
     private String nickname;
 
     @NotBlank(message =  "자기소개를 입력해주세요.")
+    @Size(max=20)
     private String introduction;
 
     private boolean admin;

--- a/src/main/java/com/gunwook/jpeople/user/entity/User.java
+++ b/src/main/java/com/gunwook/jpeople/user/entity/User.java
@@ -1,6 +1,5 @@
 package com.gunwook.jpeople.user.entity;
 
-import com.gunwook.jpeople.mypage.dto.ProfileModifyRequestDto;
 import com.gunwook.jpeople.user.dto.OauthUserDto;
 import com.gunwook.jpeople.user.dto.SignUpRequestDto;
 import jakarta.persistence.*;
@@ -83,9 +82,11 @@ public class User {
         this.profileUrl = profileUrl;
     }
 
-    public void updateIntroduction(ProfileModifyRequestDto profileModifyRequestDto){
-        this.nickname = profileModifyRequestDto.getNickname();
-        this.introduction = profileModifyRequestDto.getIntroduction();
+    public void updateNickname(String nickname){
+        this.nickname = nickname;
     }
 
+    public void updateIntroduction(String introduction){
+        this.introduction = introduction;
+    }
 }

--- a/src/main/resources/templates/mypage.html
+++ b/src/main/resources/templates/mypage.html
@@ -73,7 +73,6 @@
     </div>
 </div>
 
-
 <!-- 페이지 내용 (중앙 부분) -->
 <!-- 여기에 내용 추가 -->
 
@@ -83,8 +82,6 @@
 </div>
 
 <script>
-
-
     // 페이지네이션과 관련된 변수
     const userPerPage = 15;
     const userInfoList = document.querySelector('.user-info-list');
@@ -370,7 +367,8 @@
                     <div class="button-container" style="display: flex; flex-direction: column; justify-content: flex-start; margin-bottom: 20px">
                         <button onclick="setDefaultImage()" style="width: 200px; height: 30px;">기본 이미지로 변경</button>
                         <button onclick="changeProfileImage()" style="width: 200px; height: 30px;">프로필 사진 변경</button>
-                        <button onclick="changeProfile()" style="width: 200px; height: 30px;">닉네임, 자기소개 변경</button>
+                        <button onclick="changeNickname()" style="width: 200px; height: 30px;">닉네임 변경</button>
+                        <button onclick="changeIntroduction()" style="width: 200px; height: 30px;">자기소개 변경</button>
                     </div>
                 <!-- 추가 필요한 프로필 정보 -->
             `;
@@ -537,7 +535,6 @@
         };
         xhr.send();
     }
-
 </script>
 
 </body>

--- a/src/main/resources/templates/signup.html
+++ b/src/main/resources/templates/signup.html
@@ -27,11 +27,11 @@
         <input type="password" class="form-control" id="password">
     </div>
     <div class="mb-3">
-        <label for="nickname" class="form-label">닉네임</label>
+        <label for="nickname" class="form-label">닉네임 (최대7자)</label>
         <input type="text" class="form-control" id="nickname">
     </div>
     <div class="mb-3">
-        <label for="introduction" class="form-label">자기소개</label>
+        <label for="introduction" class="form-label">자기소개 (최대20자)</label>
         <input type="text" class="form-control" id="introduction">
     </div>
 


### PR DESCRIPTION
## 개요
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
닉네임, 자기소개 변경 로직을 추가했습니다. (기존 병합을 각각 나눠서 요청)
회원가입시 닉네임은 최대7글자, 자기소개는 최대20자로 설정가능하도록 조건을 추가했습니다.
<!---- Resolves: #(Isuue Number) -->

## PR 유형
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.  Commit message convention 참고  (Ctrl + 클릭하세요.)
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).